### PR TITLE
add reference to cmsdk

### DIFF
--- a/configpanel/Android.mk
+++ b/configpanel/Android.mk
@@ -23,5 +23,7 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_CERTIFICATE := platform
 LOCAL_PACKAGE_NAME := ConfigPanel
 
+LOCAL_STATIC_JAVA_LIBRARIES := org.cyanogenmod.platform.internal
+
 include $(BUILD_PACKAGE)
 endif


### PR DESCRIPTION
this is needed for TouchscreenGestureSettings.java in order to fix missing import of ScreenType (ScreenType has been moved to cmsdk)
