### PR TITLE
use ScreenType from cmsdk

### DIFF
--- a/configpanel/src/com/cyanogenmod/settings/device/TouchscreenGestureSettings.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/TouchscreenGestureSettings.java
@@ -16,7 +16,7 @@
 
 package com.cyanogenmod.settings.device;
 
-import com.android.internal.util.cm.ScreenType;
+import org.cyanogenmod.internal.util.ScreenType;
 
 import java.io.File;
 


### PR DESCRIPTION
updated import of ScreenType because it has moved to cmsdk
